### PR TITLE
support setting content-type in http:get 

### DIFF
--- a/magic.lambda.http.tests/HttpTests.cs
+++ b/magic.lambda.http.tests/HttpTests.cs
@@ -5,15 +5,12 @@
 
 using System.Linq;
 using System.Net.Http;
-using System.Reflection.Metadata;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using magic.lambda.http.services;
 using Xunit;
 using Newtonsoft.Json.Linq;
 using magic.node.extensions;
 using magic.node.extensions.hyperlambda;
-using Newtonsoft.Json;
 
 namespace magic.lambda.http.tests
 {

--- a/magic.lambda.http/dev_magic.lambda.http.csproj
+++ b/magic.lambda.http/dev_magic.lambda.http.csproj
@@ -10,5 +10,11 @@
     <ProjectReference Include="..\..\magic.node\magic.node.extensions\dev_magic.node.extensions.csproj" />
     <ProjectReference Include="..\..\magic.signals\magic.signals.contracts\dev_magic.signals.contracts.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+	  <_Parameter1>$(AssemblyName).tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup> 
 
 </Project>


### PR DESCRIPTION
The purpose of this PR is to add the support to set the content-type in an http request. This is not enabled within the .net framework by default, and so a new type of test was added to ensure that HttpRequest object that is generated by hl statement contains the required headers.